### PR TITLE
Using System to allow Array.Copy to work in .Net 8

### DIFF
--- a/FindRazorSourceFile/build/FindRazorSourceFileMarker.cs
+++ b/FindRazorSourceFile/build/FindRazorSourceFileMarker.cs
@@ -1,4 +1,5 @@
-﻿using System.Numerics;
+﻿using System;
+using System.Numerics;
 using System.Security.Cryptography;
 using System.Text;
 using System.Runtime.CompilerServices;


### PR DESCRIPTION
I tried to use FindRazorSourceFile in a .NET 8 project, and simply including the package reference caused my build to fail on this line: https://github.com/jsakamoto/FindRazorSourceFile/blob/master/FindRazorSourceFile/build/FindRazorSourceFileMarker.cs#L24

The exception thrown was:   FindRazorSourceFileMarker.cs(24, 9): [CS0103] The name 'Array' does not exist in the current context

Simply adding `using System;` allowed the build to complete, and I was able to find the source file I was looking for.

I am unfamiliar with building a NuGet package for multiple .NET versions, so I'm unsure if this will impact the .NET 9 or .NET 10 builds.